### PR TITLE
Extend UID for Singleton when hasMany relationship has extra data

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -420,7 +420,14 @@ function Model(opts) {
 					uid += "/" + data[opts.keys[i]];
 				}
 
-                                // Now we can do the cache lookup
+				// When there is extra_info we need a slightly longer uid for the Singleton lookup
+				if(merge && options.extra_info) {
+					for(var j=0; j<options.extra_info.id.length; j++) {
+						uid += "/" + options.extra_info.id[j];
+					}
+				}
+
+				// Now we can do the cache lookup
 				Singleton.get(uid, {
 					cache      : options.cache,
 					save_check : opts.settings.get("instance.cacheSaveCheck"),

--- a/test/integration/association-hasmany-extra.js
+++ b/test/integration/association-hasmany-extra.js
@@ -7,25 +7,43 @@ describe("hasMany extra properties", function() {
 	var Person = null;
 	var Pet    = null;
 
+	var data = { adopted: true };
+	var since14 = new Date("2014-01-01");
+	var since15 = new Date("1915-04-25");
+
 	var setup = function (opts) {
 		opts = opts || {};
 		return function (done) {
-			db.settings.set('instance.cache', false);
 
 			Person = db.define('person', {
-				name    : String,
+				name    : String
 			}, opts);
 			Pet = db.define('pet', {
 				name    : String
-			});
+			}, opts);
 			Person.hasMany('pets', Pet, {
 				since   : Date,
 				data    : Object
 			});
 
-			return helper.dropSync([ Person, Pet ], done);
-		};
-	};
+			return helper.dropSync([ Person, Pet ], function(err) {
+                if (err) return done(err);
+				Person.create([{name	: "John"},
+							   {name	: "Jane"}], function (err, people) {
+
+	                if (err) return done(err);
+					Pet.create([{name : "Deco"},
+								{name : "Mutt"}], function (err, pets) {
+
+		                if (err) return done(err);
+						people[0].addPets(pets, { since : since14, data: data }, function (err) {
+							people[1].addPets(pets, { since : since15, data: data }, done);
+						});
+					});
+				});
+			});
+        };
+    };
 
 	before(function(done) {
 		this.timeout(4000);
@@ -36,45 +54,44 @@ describe("hasMany extra properties", function() {
 		});
 	});
 
+  [true, false].forEach(function(cache) {
 	describe("if passed to addAccessor", function () {
-		before(setup());
+		before(setup( {cache:cache}));
 
-		it("should be added to association", function (done) {
-			Person.create([{
-				name    : "John"
-			}], function (err, people) {
-				Pet.create([{
-					name : "Deco"
-				}, {
-					name : "Mutt"
-				}], function (err, pets) {
-					var data = { adopted: true };
+		it("should be added to association and correctly retrieved " + (cache ? "with" : "without") + " the cache", function (done) {
+		  Person.find({ name: "John" }, { autoFetch : true }).first(function (err, John) {
+			should.equal(err, null);
 
-					people[0].addPets(pets, { since : new Date(), data: data }, function (err) {
-						should.equal(err, null);
+			John.should.have.property("pets");
+			should(Array.isArray(John.pets));
 
-						Person.find({ name: "John" }, { autoFetch : true }).first(function (err, John) {
-							should.equal(err, null);
+			John.pets.length.should.equal(2);
 
-							John.should.have.property("pets");
-							should(Array.isArray(pets));
+			John.pets[0].should.have.property("name");
+			John.pets[0].should.have.property("extra");
+			John.pets[0].extra.should.be.a("object");
+			John.pets[0].extra.should.have.property("since");
+			should(John.pets[0].extra.since instanceof Date);
+            should.equal(John.pets[0].extra.since.getFullYear(), since14.getFullYear());
 
-							John.pets.length.should.equal(2);
+			should.equal(typeof John.pets[0].extra.data, 'object');
+			should.equal(JSON.stringify(data), JSON.stringify(John.pets[0].extra.data));
 
-							John.pets[0].should.have.property("name");
-							John.pets[0].should.have.property("extra");
-							John.pets[0].extra.should.be.a("object");
-							John.pets[0].extra.should.have.property("since");
-							should(John.pets[0].extra.since instanceof Date);
+			// Do a second retrieve (which will break the cache)
+			Person.find({name: "Jane"}, {autoFetch:true}).first(function(err, Jane) {
+			  should.equal(err, null);
 
-							should.equal(typeof John.pets[0].extra.data, 'object');
-							should.equal(JSON.stringify(data), JSON.stringify(John.pets[0].extra.data));
+			  Jane.pets[0].should.have.property("name");
+			  Jane.pets[0].should.have.property("extra");
+			  Jane.pets[0].extra.should.be.a("object");
+			  Jane.pets[0].extra.should.have.property("since");
+			  should(Jane.pets[0].extra.since instanceof Date);
+			  should.equal(Jane.pets[0].extra.since.getFullYear(), since15.getFullYear());
 
-							return done();
-						});
-					});
-				});
-			});
-		});
-	});
+			  return done();
+            })
+		  });
+        });
+    });
+  });
 });


### PR DESCRIPTION
When hasMany relationship has extra data, then the UID used by Singleton for the associative entity needs to include both keys to be sure we get the right set of extra data.
